### PR TITLE
Fixed bug in ParsedEntity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .settings
 .classpath
 target
+
+.idea/
+
+*.iml

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/ParsedEntity.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/ParsedEntity.java
@@ -75,17 +75,31 @@ public class ParsedEntity<T> {
 
 				if(field.getType()==String.class) {
 					field.set(target,rs.getString(column));
+
 				} else if(field.getType()==BigDecimal.class) {
 					field.set(target,rs.getBigDecimal(column));
+
 				} else if(field.getType()==Integer.class || field.getType()==Integer.TYPE) {
-					int value = rs.getInt(column);
-					field.set(target, rs.wasNull() ? null : value);
-				} else if(field.getType()==Long.class || field.getType()==Long.TYPE) {
+                    int value = rs.getInt(column);
+                    if (field.getType().isPrimitive() && rs.wasNull()) {
+                        throw new NullPointerException("Cannot set NULL value to field with type int");
+                    }
+                    field.set(target, rs.wasNull() ? null : value);
+
+                } else if(field.getType()==Long.class || field.getType()==Long.TYPE) {
 					long value = rs.getLong(column);
+                    if (field.getType().isPrimitive() && rs.wasNull()) {
+                        throw new NullPointerException("Cannot set NULL value to field with type long");
+                    }
 					field.set(target, rs.wasNull() ? null : value);
+
 				} else if(field.getType()==Boolean.class || field.getType()==Boolean.TYPE) {
 					boolean value = rs.getBoolean(column);
+                    if (field.getType().isPrimitive() && rs.wasNull()) {
+                        throw new NullPointerException("Cannot set NULL value to field with type boolean");
+                    }
 					field.set(target, rs.wasNull() ? null : value);
+
 				} else if(Enum.class.isAssignableFrom(field.getType())) {
 					String value = rs.getString(column);
 					if(value==null) {

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/ParsedEntity.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/ParsedEntity.java
@@ -78,18 +78,21 @@ public class ParsedEntity<T> {
 				} else if(field.getType()==BigDecimal.class) {
 					field.set(target,rs.getBigDecimal(column));
 				} else if(field.getType()==Integer.class || field.getType()==Integer.TYPE) {
-					field.set(target,rs.getInt(column));
+					int value = rs.getInt(column);
+					field.set(target, rs.wasNull() ? null : value);
 				} else if(field.getType()==Long.class || field.getType()==Long.TYPE) {
-					field.set(target,rs.getLong(column));
+					long value = rs.getLong(column);
+					field.set(target, rs.wasNull() ? null : value);
 				} else if(field.getType()==Boolean.class || field.getType()==Boolean.TYPE) {
-					field.set(target,rs.getBoolean(column));
+					boolean value = rs.getBoolean(column);
+					field.set(target, rs.wasNull() ? null : value);
 				} else if(Enum.class.isAssignableFrom(field.getType())) {
 					String value = rs.getString(column);
 					if(value==null) {
 						field.set(target, null);
 					} else {
 						for(Object o : field.getType().getEnumConstants()) {
-							if(o.toString().compareTo(value.toString())==0) {
+							if(o.toString().compareTo(value)==0) {
 								field.set(target, o);
 							}
 						}


### PR DESCRIPTION
Nullable number columns no longer default to `0` when reading from DB

`ResultSet.getInt()` returns primitive which defaults to 0 when null (similar with others like `getLong` and `getBoolean`), if we want proper behaviour with nullable columns, we must check if last result was null.

Proposed change will produce NPE when assigning NULL to primitive type, but that seems like proper behaviour, as it in that case there is a bug in the code (either improperly set DB or entity)