### PR TITLE
Added support for Spring Boot 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ i have been using (and improving) it for quite a while now, and found it useful 
 
 i started this mostly out of lazyness. i didn't want the complexity of full blown JPA criteria, and i also wanted less runtim magic than what spring data repositories do. for me, this library is a good balance between simplicity and minimizing boilerplate code. basically, once the entity is defined, the only thing i have to deal with the code to find specific entries (more on the pattern i use below).
 
-this uses `java.sql.DataSource` and `NamedParameterJdbcTemplate` from spring-jdbc, the annotations from `javax.persistence`, and plain reflection to do the actual mapping. it can currently map most standard field types (including enums).
+this uses `java.sql.DataSource` and `NamedParameterJdbcTemplate` from spring-jdbc, the annotations from `javax.persistence` or `jakarta.persistence`, and plain reflection to do the actual mapping. it can currently map most standard field types (including enums).
 
 it also offers pretty extensive and direct control over the SQL that is produced.
 
@@ -24,23 +24,24 @@ big thanks to everyone who has contributed to this, especially @mdjimy
 
 ### compatibility
 
-Supports Spring Boot 2.0.x - Spring Boot 2.3.x.
+Supports Spring Boot 2.x - Spring Boot 3.x.
 
-Java 8 - Java 14. 
+Java 8 - Java 17. 
 
+Both Javax and Jakarta Persistence API are supported
 
 
 ### dependencies
 
 this has very few dependencies - and thanks to @mdjimy, there are even less from > 0.52. the few things you DO need are as these:
 
-since the JPA APIs are a big mess, packaging wise, and we only really need a handful of annotations from there, `javax-persinstence` , it is now set to "provided" - so you will have to pick your poison. i normally use:
+since the JPA APIs are a big mess, packaging wise, and we only really need a handful of annotations from there, Persistence API , it is now set to "optional" - so you will have to pick your poison. i normally use:
 
 ```xml
 <dependency>
-	<groupId>javax.persistence</groupId>
-    <artifactId>javax.persistence-api</artifactId>
-	<version>2.2</version>
+    <groupId>jakarta.persistence</groupId>
+    <artifactId>jakarta.persistence-api</artifactId>
+    <version>2.2</version>
 </dependency>
 ```
 

--- a/dbutil-api/pom.xml
+++ b/dbutil-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.disk0.dbutil</groupId>
 		<artifactId>dbutil</artifactId>
-		<version>0.0.77-SNAPSHOT</version>
+		<version>0.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>dbutil-api</artifactId>

--- a/dbutil-api/src/main/java/de/disk0/dbutil/api/entities/BaseEntity.java
+++ b/dbutil-api/src/main/java/de/disk0/dbutil/api/entities/BaseEntity.java
@@ -1,14 +1,17 @@
 package de.disk0.dbutil.api.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 @Entity
+@javax.persistence.Entity
 public class BaseEntity<T> {
 
 	@Id
+	@javax.persistence.Id
 	@Column(name = "id", unique = true, nullable = false)
+	@javax.persistence.Column(name = "id", unique = true, nullable = false)
 	private T id;
 
 	public T getId() {

--- a/dbutil-api/src/main/java/de/disk0/dbutil/api/entities/BaseGuidEntity.java
+++ b/dbutil-api/src/main/java/de/disk0/dbutil/api/entities/BaseGuidEntity.java
@@ -1,14 +1,17 @@
 package de.disk0.dbutil.api.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 @Entity
+@javax.persistence.Entity
 public class BaseGuidEntity extends BaseEntity<String> {
 
 	@Id
+	@javax.persistence.Id
 	@Column(name = "id", unique = true, nullable = false)
+	@javax.persistence.Column(name = "id", unique = true, nullable = false)
 	private String id;
 
 	public String getId() {

--- a/dbutil-impl/pom.xml
+++ b/dbutil-impl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.disk0.dbutil</groupId>
 		<artifactId>dbutil</artifactId>
-		<version>0.0.77-SNAPSHOT</version>
+		<version>0.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>dbutil-impl</artifactId>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>de.disk0.dbutil</groupId>
 			<artifactId>dbutil-api</artifactId>
-			<version>0.0.77-SNAPSHOT</version>
+			<version>0.1.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -30,6 +30,11 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/dbutil-impl/pom.xml
+++ b/dbutil-impl/pom.xml
@@ -17,14 +17,16 @@
 			<artifactId>dbutil-api</artifactId>
 			<version>0.1.0-SNAPSHOT</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-core</artifactId>
+            <optional>true</optional>
 		</dependency>
 		
 		<dependency>

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/AbstractMappingRepository.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/AbstractMappingRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.persistence.NonUniqueResultException;
+import de.disk0.dbutil.impl.util.PersistenceApiUtils;
 import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
@@ -212,7 +212,7 @@ public abstract class AbstractMappingRepository<T> implements RowMapper<T> {
 			log.warn("-------- query failed: "+sql+" / "+params,e);
 			throw new SqlException("SQL.REPO.LIST_FAILED",new Object[] { e.getMessage() },  e);
 		}
-		throw new NonUniqueResultException();
+		throw PersistenceApiUtils.nonUniqueResultException();
 	}
 
 	public int delete(SimpleQuery q) throws SqlException {

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/AbstractMappingRepository.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/AbstractMappingRepository.java
@@ -5,16 +5,17 @@ import java.security.InvalidParameterException;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+import de.disk0.dbutil.impl.micrometer.MicrometerAdapter;
 import de.disk0.dbutil.impl.util.PersistenceApiUtils;
 import javax.sql.DataSource;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -24,25 +25,9 @@ import de.disk0.dbutil.api.Select;
 import de.disk0.dbutil.api.exceptions.SqlException;
 import de.disk0.dbutil.impl.util.ParsedEntity;
 import de.disk0.dbutil.impl.util.ParsedEntity.ParsedColumn;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.ImmutableTag;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.noop.NoopTimer;
 
+@CommonsLog
 public abstract class AbstractMappingRepository<T> implements RowMapper<T> {
-	
-	private static Log log = LogFactory.getLog(AbstractMappingRepository.class);
-
-	//@Autowired
-	//protected DataSource dataSource;
-	
-	@Autowired(required = false)
-	private MeterRegistry meterRegistry;
-	
-	private Timer timer;
-	private Map<String,Counter> counters;
 
 	protected ParsedEntity<T> pe;
 	
@@ -52,6 +37,9 @@ public abstract class AbstractMappingRepository<T> implements RowMapper<T> {
 	
 	@Autowired
 	private NamedParameterJdbcTemplate template;
+
+	@Autowired(required = false)
+	private MicrometerAdapter micrometerAdapter;
 	
 	@SuppressWarnings("unchecked")
 	protected Class<T> getClazz() {
@@ -60,36 +48,6 @@ public abstract class AbstractMappingRepository<T> implements RowMapper<T> {
 		}
 		return clazz;
 	}
-	
-	public Timer getTimer() {
-		if(timer == null) {
-			if(meterRegistry != null) {
-				List<Tag> tags =  new ArrayList<>();
-				tags.add(new ImmutableTag("object", getClazz().getSimpleName()));
-				timer = meterRegistry.timer("dbutil.sql.find",tags);
-			} else {
-				timer = new NoopTimer(null);
-			}
-		}
-		return timer;
-	}
-	
-	private Counter getCounter(String type) {
-		Counter c = counters.get(type);
-		if(c == null) {
-			List<Tag> tags =  new ArrayList<>();
-			tags.add(new ImmutableTag("object", getClazz().getSimpleName()));
-			tags.add(new ImmutableTag("type", type));
-			c = meterRegistry.counter("dbutil.sql.find",tags);
-			counters.put(type, c);
-		}
-		return c;
-	}
-
-	private void tick(String type) {
-		getCounter(type).increment();
-	}
-
 		
 	public ParsedEntity<T> getParsedEntity() {
 		if(pe==null) {
@@ -178,7 +136,7 @@ public abstract class AbstractMappingRepository<T> implements RowMapper<T> {
 	}
 	
 	public List<T> find(String sql, Map<String,Object> params) throws SqlException {
-		long timer = System.nanoTime();
+		Instant timerStart = Instant.now();
 		try {
 			NamedParameterJdbcTemplate t = getTemplate();
 			long start = System.currentTimeMillis();
@@ -190,8 +148,14 @@ public abstract class AbstractMappingRepository<T> implements RowMapper<T> {
 			log.warn("-------- query failed: "+sql+" / "+params,e);
 			throw new SqlException("SQL.REPO.LIST_FAILED",new Object[] { e.getMessage() },  e);
 		} finally {
-			long end = System.nanoTime();
-			getTimer().record(end-timer, TimeUnit.NANOSECONDS);
+			if (micrometerAdapter != null) {
+				Instant timerEnd = Instant.now();
+				micrometerAdapter.record(
+						Duration.between(timerStart, timerEnd),
+						"dbutil.sql.find",
+						MicrometerAdapter.Tag.of("object", getClazz().getSimpleName())
+				);
+			}
 		}
 	}
 

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/config/ReaderConfig.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/config/ReaderConfig.java
@@ -1,8 +1,5 @@
 package de.disk0.dbutil.impl.config;
 
-import javax.sql.DataSource;
-
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -10,27 +7,26 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
+import javax.sql.DataSource;
+
 @Configuration
+@ConditionalOnProperty(name = "spring.reader.enabled", havingValue = "true")
 public class ReaderConfig {
 
-
-	@Bean(name="readerDSprops")
+	@Bean
 	@ConfigurationProperties("spring.reader")
-	@ConditionalOnProperty(name = "spring.reader.enabled", havingValue = "true", matchIfMissing = false)
-	public static DataSourceProperties readerDSProperties() {
+	public static DataSourceProperties readerDSprops() {
 		return new DataSourceProperties();
 	}
-	
-	@Bean(name="readerDS")
-	@ConditionalOnProperty(name = "spring.reader.enabled", havingValue = "true", matchIfMissing = false)
-	public static DataSource readerDS( @Qualifier("readerDSprops") DataSourceProperties readerDSprops) {
-		return readerDSprops.initializeDataSourceBuilder().build();
+
+	@Bean
+	public static DataSource readerDS() {
+		return readerDSprops().initializeDataSourceBuilder().build();
 	}
 
-	@Bean(name = "readerTemplate")
-	@ConditionalOnProperty(name = "spring.reader.enabled", havingValue = "true", matchIfMissing = false)
-	public static NamedParameterJdbcTemplate readerTemplate( @Qualifier("readerDS") DataSource readerDS) {
-		return new NamedParameterJdbcTemplate(readerDS);
-	}	
-	
+	@Bean
+	public static NamedParameterJdbcTemplate readerTemplate() {
+		return new NamedParameterJdbcTemplate(readerDS());
+	}
+
 }

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/config/ReaderDatasource.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/config/ReaderDatasource.java
@@ -1,5 +1,0 @@
-package de.disk0.dbutil.impl.config;
-
-public class ReaderDatasource {
-
-}

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/micrometer/MicrometerAdapter.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/micrometer/MicrometerAdapter.java
@@ -1,0 +1,21 @@
+package de.disk0.dbutil.impl.micrometer;
+
+import lombok.Value;
+
+import java.time.Duration;
+
+public interface MicrometerAdapter {
+
+	void record(Duration duration, String metricName, Tag... tags);
+
+	@Value
+	class Tag {
+		String key;
+		String value;
+
+		public static Tag of(String key, String value) {
+			return new Tag(key, value);
+		}
+	}
+
+}

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/micrometer/MicrometerAdapterImpl.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/micrometer/MicrometerAdapterImpl.java
@@ -1,0 +1,35 @@
+package de.disk0.dbutil.impl.micrometer;
+
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Configuration
+@RequiredArgsConstructor
+@ConditionalOnClass(MeterRegistry.class)
+@ConditionalOnProperty(name = "dbutil.micrometer.enabled", havingValue = "true")
+public class MicrometerAdapterImpl implements MicrometerAdapter {
+
+	private final ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+	@Override
+	public void record(Duration duration, String metricName, Tag... tags) {
+		MeterRegistry meterRegistry = meterRegistryProvider.getIfAvailable();
+		if (meterRegistry == null) return;
+
+		Iterable<io.micrometer.core.instrument.Tag> micrometerTags = Arrays.stream(tags)
+				.map(tag -> new ImmutableTag(tag.getKey(), tag.getValue()))
+				.collect(Collectors.toList());
+
+		meterRegistry.timer(metricName, micrometerTags).record(duration);
+	}
+
+}

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/mysql/MysqlSelect.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/mysql/MysqlSelect.java
@@ -5,8 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.Table;
-
 import de.disk0.dbutil.api.Aggregate;
 import de.disk0.dbutil.api.Comparator;
 import de.disk0.dbutil.api.Condition;
@@ -18,6 +16,7 @@ import de.disk0.dbutil.api.SubSelect;
 import de.disk0.dbutil.api.TableReference;
 import de.disk0.dbutil.api.entities.BaseEntity;
 import de.disk0.dbutil.impl.util.AliasGenerator;
+import de.disk0.dbutil.impl.util.PersistenceApiUtils;
 
 public class MysqlSelect implements Select {
 
@@ -94,7 +93,7 @@ public class MysqlSelect implements Select {
 	
 	@Override
 	public TableReference fromTable(Class<? extends BaseEntity<?>> table) {
-		return fromTable(table.getAnnotation(Table.class).name());
+		return fromTable(PersistenceApiUtils.getTableName(table));
 	}
 	
 	@Override

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/mysql/MysqlTableReferenceSimple.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/mysql/MysqlTableReferenceSimple.java
@@ -5,14 +5,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.Table;
-
 import de.disk0.dbutil.api.Aggregate;
 import de.disk0.dbutil.api.Field;
 import de.disk0.dbutil.api.JoinTable;
 import de.disk0.dbutil.api.TableReference;
 import de.disk0.dbutil.api.entities.BaseEntity;
 import de.disk0.dbutil.impl.util.AliasGenerator;
+import de.disk0.dbutil.impl.util.PersistenceApiUtils;
 
 public class MysqlTableReferenceSimple implements TableReference {
 
@@ -71,7 +70,7 @@ public class MysqlTableReferenceSimple implements TableReference {
 
 	@Override
 	public JoinTable leftJoin(Class<? extends BaseEntity<?>> table) {
-		return leftJoin(table.getAnnotation(Table.class).name());
+		return leftJoin(PersistenceApiUtils.getTableName(table));
 	}
 	
 	@Override
@@ -84,7 +83,7 @@ public class MysqlTableReferenceSimple implements TableReference {
 
 	@Override
 	public JoinTable leftOuterJoin(Class<? extends BaseEntity<?>> table) {
-		return leftOuterJoin(table.getAnnotation(Table.class).name());
+		return leftOuterJoin(PersistenceApiUtils.getTableName(table));
 	}
 	
 	@Override
@@ -97,7 +96,7 @@ public class MysqlTableReferenceSimple implements TableReference {
 
 	@Override
 	public JoinTable join(Class<? extends BaseEntity<?>> table) {
-		return join(table.getAnnotation(Table.class).name());
+		return join(PersistenceApiUtils.getTableName(table));
 	}
 	
 	@Override

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/mysql/MysqlTableReferenceSubSelect.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/mysql/MysqlTableReferenceSubSelect.java
@@ -5,8 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.Table;
-
 import de.disk0.dbutil.api.Aggregate;
 import de.disk0.dbutil.api.Comparator;
 import de.disk0.dbutil.api.Condition;
@@ -17,6 +15,7 @@ import de.disk0.dbutil.api.SubSelect;
 import de.disk0.dbutil.api.TableReference;
 import de.disk0.dbutil.api.entities.BaseEntity;
 import de.disk0.dbutil.impl.util.AliasGenerator;
+import de.disk0.dbutil.impl.util.PersistenceApiUtils;
 
 public class MysqlTableReferenceSubSelect extends MysqlTableReferenceSimple implements SubSelect {
 
@@ -106,7 +105,7 @@ public class MysqlTableReferenceSubSelect extends MysqlTableReferenceSimple impl
 
 	@Override
 	public TableReference fromTable(Class<? extends BaseEntity<?>> table) {
-		return fromTable(table.getAnnotation(Table.class).name());
+		return fromTable(PersistenceApiUtils.getTableName(table));
 	}
 	
 	public SubSelect from() {

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/ParsedEntity.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/ParsedEntity.java
@@ -7,8 +7,7 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Table;
+import de.disk0.dbutil.impl.util.PersistenceApiUtils.Column;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,20 +26,20 @@ public class ParsedEntity<T> {
 			for(Field f : c.getDeclaredFields()) {
 				if(x.contains(f.getName())) continue;
 				x.add(f.getName());
-				if(f.getAnnotation(Column.class)!=null) {
-					Column column = f.getAnnotation(Column.class);
+				Column column = PersistenceApiUtils.getColumn(f);
+				if(column!=null) {
 					String name = f.getName();
-					if(!column.name().equals("")) {
-						name = column.name();
+					if(!column.getName().equals("")) {
+						name = column.getName();
 					}
-					columns.add(new ParsedColumn(f, name, column.insertable(), column.updatable()));
+					columns.add(new ParsedColumn(f, name, column.isInsertable(), column.isUpdatable()));
 				}
 			}
 			c = c.getSuperclass();
 			if(c==null) break;
 			
 		} while(clazz.getSuperclass()!=null);
-		tableName = clazz.getAnnotation(Table.class).name();
+		tableName = PersistenceApiUtils.getTableName(clazz);
 		
 	}
 	

--- a/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/PersistenceApiUtils.java
+++ b/dbutil-impl/src/main/java/de/disk0/dbutil/impl/util/PersistenceApiUtils.java
@@ -1,0 +1,149 @@
+package de.disk0.dbutil.impl.util;
+
+import lombok.SneakyThrows;
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+import org.springframework.lang.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
+
+@UtilityClass
+public class PersistenceApiUtils {
+
+	private static final Function<Field, Column> JAKARTA_COLUMN = columnAccessor("jakarta.persistence.Column");
+	private static final Function<Field, Column> JAVAX_COLUMN = columnAccessor("javax.persistence.Column");
+
+	private static final Function<Class<?>, Table> JAKARTA_TABLE = tableAccessor("jakarta.persistence.Table");
+	private static final Function<Class<?>, Table> JAVAX_TABLE = tableAccessor("javax.persistence.Table");
+
+	private static final Class<? extends RuntimeException> NON_UNIQUE_RESULT_EXCEPTION_CLASS;
+
+	static {
+		Class exceptionClass = initPersistenceClass("jakarta.persistence.NonUniqueResultException");
+		if (exceptionClass == null) exceptionClass = initPersistenceClass("javax.persistence.NonUniqueResultException");
+		if (exceptionClass == null) throw new RuntimeException("Missing JAVAX or JAKARTA persistence API");
+
+		NON_UNIQUE_RESULT_EXCEPTION_CLASS = exceptionClass;
+	}
+
+	@SneakyThrows
+	public static RuntimeException nonUniqueResultException() {
+		return NON_UNIQUE_RESULT_EXCEPTION_CLASS.getConstructor().newInstance();
+	}
+
+	@Nullable
+	public static Column getColumn(Field field) {
+		Column column = JAKARTA_COLUMN.apply(field);
+		if (column != null) return column;
+
+		return JAVAX_COLUMN.apply(field);
+	}
+
+	@Nullable
+	public static Table getTable(Class<?> entity) {
+		Table column = JAKARTA_TABLE.apply(entity);
+		if (column != null) return column;
+
+		return JAVAX_TABLE.apply(entity);
+	}
+
+	@Nullable
+	public static String getTableName(Class<?> entity) {
+		Table table = getTable(entity);
+		return table != null ? table.getName() : null;
+	}
+
+	@Nullable
+	private static <T> Class<T> initPersistenceClass(String className) {
+		try {
+			return (Class<T>) Class.forName(className);
+		} catch (ClassNotFoundException e) {
+			return null;
+		}
+	}
+
+	@SneakyThrows
+	private static <T> T propertyAccessor(Annotation field, String annotationProperty) {
+		return (T) field.getClass().getMethod(annotationProperty).invoke(field);
+	}
+
+	private static Function<Field, Column> columnAccessor(String columnClassName) {
+		Class<? extends Annotation> columnClass = initPersistenceClass(columnClassName);
+		if (columnClass == null) return field -> null;
+
+		Function<Annotation, String> nameAccessor = field -> propertyAccessor(field, "name");
+		Predicate<Annotation> uniqueAccessor = field -> propertyAccessor(field, "unique");
+		Predicate<Annotation> nullableAccessor = field -> propertyAccessor(field, "nullable");
+		Predicate<Annotation> insertableAccessor = field -> propertyAccessor(field, "insertable");
+		Predicate<Annotation> updatableAccessor = field -> propertyAccessor(field, "updatable");
+		Function<Annotation, String> columnDefinitionAccessor = field -> propertyAccessor(field, "columnDefinition");
+		Function<Annotation, String> tableAccessor = field -> propertyAccessor(field, "table");
+		ToIntFunction<Annotation> lengthAccessor = field -> propertyAccessor(field, "length");
+		ToIntFunction<Annotation> precisionAccessor = field -> propertyAccessor(field, "precision");
+		ToIntFunction<Annotation> scaleAccessor = field -> propertyAccessor(field, "scale");
+
+		return field -> {
+			Annotation annotation = field.getAnnotation(columnClass);
+			if (annotation == null) return null;
+
+			return new Column(
+					nameAccessor.apply(annotation),
+					uniqueAccessor.test(annotation),
+					nullableAccessor.test(annotation),
+					insertableAccessor.test(annotation),
+					updatableAccessor.test(annotation),
+					columnDefinitionAccessor.apply(annotation),
+					tableAccessor.apply(annotation),
+					lengthAccessor.applyAsInt(annotation),
+					precisionAccessor.applyAsInt(annotation),
+					scaleAccessor.applyAsInt(annotation)
+			);
+		};
+	}
+
+	private static Function<Class<?>, Table> tableAccessor(String tableClassName) {
+		Class<? extends Annotation> tableClass = initPersistenceClass(tableClassName);
+		if (tableClass == null) return field -> null;
+
+		Function<Annotation, String> nameAccessor = field -> propertyAccessor(field, "name");
+		Function<Annotation, String> catalogAccessor = field -> propertyAccessor(field, "catalog");
+		Function<Annotation, String> schemaAccessor = field -> propertyAccessor(field, "schema");
+
+		return entityClass -> {
+			Annotation annotation = entityClass.getAnnotation(tableClass);
+			if (annotation == null) return null;
+
+			return new Table(
+					nameAccessor.apply(annotation),
+					catalogAccessor.apply(annotation),
+					schemaAccessor.apply(annotation)
+			);
+		};
+	}
+
+	@Value
+	public static class Table {
+		String name;
+		String catalog;
+		String schema;
+	}
+
+	@Value
+	public static class Column {
+		String name;
+		boolean unique;
+		boolean nullable;
+		boolean insertable;
+		boolean updatable;
+		String columnDefinition;
+		String table;
+		int length;
+		int precision;
+		int scale;
+	}
+
+}

--- a/dbutil-impl/src/test/java/de/disk0/dbutil/impl/hund/Hund.java
+++ b/dbutil-impl/src/test/java/de/disk0/dbutil/impl/hund/Hund.java
@@ -1,7 +1,7 @@
 package de.disk0.dbutil.impl.hund;
 
-import javax.persistence.Column;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
 
 import de.disk0.dbutil.api.entities.BaseGuidEntity;
 

--- a/dbutil-impl/src/test/java/de/disk0/dbutil/impl/katze/Katze.java
+++ b/dbutil-impl/src/test/java/de/disk0/dbutil/impl/katze/Katze.java
@@ -1,7 +1,7 @@
 package de.disk0.dbutil.impl.katze;
 
-import javax.persistence.Column;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
 
 import de.disk0.dbutil.api.entities.BaseGuidEntity;
 

--- a/dbutil-impl/src/test/java/de/disk0/dbutil/impl/mysql/entities/BigDecimalEntity.java
+++ b/dbutil-impl/src/test/java/de/disk0/dbutil/impl/mysql/entities/BigDecimalEntity.java
@@ -2,8 +2,8 @@ package de.disk0.dbutil.impl.mysql.entities;
 
 import java.math.BigDecimal;
 
-import javax.persistence.Column;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
 
 import de.disk0.dbutil.api.entities.BaseGuidEntity;
 

--- a/dbutil-impl/src/test/java/de/disk0/dbutil/impl/pets/Pet.java
+++ b/dbutil-impl/src/test/java/de/disk0/dbutil/impl/pets/Pet.java
@@ -1,7 +1,7 @@
 package de.disk0.dbutil.impl.pets;
 
-import javax.persistence.Column;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
 
 import de.disk0.dbutil.api.entities.BaseGuidEntity;
 

--- a/dbutil-schema-check/pom.xml
+++ b/dbutil-schema-check/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.disk0.dbutil</groupId>
 		<artifactId>dbutil</artifactId>
-		<version>0.0.77-SNAPSHOT</version>
+		<version>0.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>dbutil-schema-check</artifactId>

--- a/dbutils-examples/pom.xml
+++ b/dbutils-examples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.disk0.dbutil</groupId>
 		<artifactId>dbutil</artifactId>
-		<version>0.0.77-SNAPSHOT</version>
+		<version>0.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>dbutils-examples</artifactId>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>de.disk0.dbutil</groupId>
 			<artifactId>dbutil-impl</artifactId>
-			<version>0.0.77-SNAPSHOT</version>
+			<version>0.1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/dbutils-examples/src/main/java/de/disk0/dbutil/impl/ExampleEntity.java
+++ b/dbutils-examples/src/main/java/de/disk0/dbutil/impl/ExampleEntity.java
@@ -1,7 +1,7 @@
 package de.disk0.dbutil.impl;
 
-import javax.persistence.Column;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
 
 import de.disk0.dbutil.api.entities.BaseGuidEntity;
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.6</version>
+		<version>3.0.1</version>
 	</parent>
 
 	<groupId>de.disk0.dbutil</groupId>
 	<artifactId>dbutil</artifactId>
-	<version>0.0.77-SNAPSHOT</version>
+	<version>0.1.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 
@@ -22,14 +22,21 @@
 	</modules>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>8</java.version>
+		<maven.compiler.release>8</maven.compiler.release>
 	</properties>
 
 	<dependencies>
 		<dependency>
+			<groupId>jakarta.persistence</groupId>
+			<artifactId>jakarta.persistence-api</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>javax.persistence</groupId>
 			<artifactId>javax.persistence-api</artifactId>
-			<scope>provided</scope>
+			<version>2.2</version>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
 			<version>2.2</version>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Added support for Spring Framework 6.x and Spring Boot 3.x whilst support for Spring Framework 5.x and Spring Boot 2.x should remain intact.

Since Spring Framework 6.x switched from Javax to Jakarta Persistence API added `PersistenceApiUtils` to provide workaround for difference in package names of Persistence API annotations.

Since all project dependencies were updated to newer versions JVM 17 is now baseline for building the project but interoperability with JAVA 8 was preserved by setting cross compilation to JAVA 8 bytecode. This means that library may still be used on older JVM with Spring Framework 5.x and Spring Boot 2.x.

Since purpose of this library was to be lightweight alternative to full blown JPA criteria / ORM I decided to remove `spring-boot-starter-actuator` dependency and make `micrometer-core` as optional dependency to prevent their transitive inclusion to dependent projects.
`MicrometerAdapter` was introduced to provide layer of isolation from directly accessing `micrometer-core` code which might be missing on the classpath so that `AbstractMappingRepository` can be used safely.

Finally, since some project may do not want to meter `AbstractMappingRepository` or have already own metrics implemented I decided to by-default disable it's metrics, meaning they now have to be explicitly enabled using property `dbutil.micrometer.enabled=true`.
Default behaviour (disabled micrometer integration) may be discussed but my view is that micrometer integration should be considered more-like additional supported feature which may be turned on if desired.